### PR TITLE
Switch to Fetch-then-Render

### DIFF
--- a/src/CountryFilter.module.scss
+++ b/src/CountryFilter.module.scss
@@ -5,6 +5,9 @@
   :global {
     font-size: 1.5rem;
     font-weight: 400;
+    input:disabled {
+      opacity: .5;
+    }
   }
 }
 .checkbox {

--- a/src/CountryFilter.tsx
+++ b/src/CountryFilter.tsx
@@ -1,10 +1,11 @@
-import React, { FC } from "react";
+import { FC } from "react";
 import { Nationalities } from "./types/User";
 import styles from "./CountryFilter.module.scss";
 
 const CountryFilter: FC<{
-  nationalities: Nationalities;
-  onSelect: (nationalities: Nationalities) => void;
+  onSelect: (nationalities: Nationalities) => void
+  nationalities: Nationalities
+  disabled: boolean
 }> = (props) => {
   return (
     <fieldset className={styles.fieldset}>
@@ -23,15 +24,14 @@ const CountryFilter: FC<{
                 id={nat.code}
                 name={nat.name}
                 checked={nat.selected}
-                onChange={() =>
-                  props.onSelect({
-                    ...props.nationalities,
-                    [nat.code]: {
-                      ...nat,
-                      selected: !nat.selected,
-                    },
-                  })
-                }
+                disabled={props.disabled}
+                onChange={() => props.onSelect({
+                  ...props.nationalities,
+                  [nat.code]: {
+                    ...nat,
+                    selected: !nat.selected,
+                  },
+                })}
               />
             </div>
           );

--- a/src/ErrorBoundary.tsx
+++ b/src/ErrorBoundary.tsx
@@ -1,0 +1,39 @@
+import { Component, ErrorInfo, ReactNode } from 'react'
+
+interface IProps {
+  children?: ReactNode
+  fallback?: ReactNode
+}
+
+interface IState {
+  hasError: boolean
+}
+
+class ErrorBoundary extends Component<IProps, IState> {
+  public state: IState = {
+    hasError: false,
+  }
+
+  public static defaultProps: IProps = {
+    fallback: <div>Sorry… there was an error</div>,
+  }
+
+  public static getDerivedStateFromError(_: Error): IState {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true }
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('Uncaught error:', error, errorInfo)
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return <p style={{ backgroundColor: 'rgba(255,0,0, .15)', color: 'red', padding: '1rem', borderRadius: '.5rem' }}>{this.props.fallback}</p>
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -1,9 +1,9 @@
-import React, { FC } from "react";
+import { FC, memo } from "react";
 import getAgeGroup from "./helpers/ageGroup";
 import styles from "./Table.module.scss";
-import { Users } from "./types/User";
+import { User, Users } from "./types/User";
 
-const Table: FC<{ data: Users }> = (props) => {
+const Table: FC<{ users: Users }> = memo((props) => {
   return (
     <div className={styles.table}>
       <table>
@@ -17,7 +17,7 @@ const Table: FC<{ data: Users }> = (props) => {
         </thead>
         <tbody>
           {/* Add placeholder rows for during fetch */}
-          {props.data.map((user) => {
+          {props.users && props.users?.map((user: User) => {
             const ageGroup = getAgeGroup(user.dob.age);
             return (
               <tr key={user.login.uuid}>
@@ -36,9 +36,9 @@ const Table: FC<{ data: Users }> = (props) => {
                   <div className={`${styles.ageGroup}`}>
                     <div
                       className={`${styles.dotColor}`}
-                      style={{ backgroundColor: ageGroup.color }}
+                      style={{ backgroundColor: ageGroup?.color }}
                     />
-                    <div>{ageGroup.label}</div>
+                    <div>{ageGroup?.label}</div>
                   </div>
                 </td>
                 <td>
@@ -49,13 +49,13 @@ const Table: FC<{ data: Users }> = (props) => {
           })}
         </tbody>
       </table>
-      {props.data.length ? null : (
+      {props.users && props.users?.length ? null : (
         <div className={`${styles.noData} flex-row flex-center`}>
           No items to show
         </div>
       )}
     </div>
   );
-};
+});
 
 export default Table;

--- a/src/Users.tsx
+++ b/src/Users.tsx
@@ -1,0 +1,13 @@
+import { FC } from "react"
+import Table from "./Table"
+import { APIResponse } from "./types/Client";
+import { Resource } from "./helpers/promiseWrapper";
+
+const Users: FC<{ resource: Resource<APIResponse> }> = (props) => {
+  const users = props.resource?.read()?.results ?? [];
+  return (
+    <Table users={users} />
+  )
+}
+
+export default Users

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,13 @@
+import { APIResponse } from "./types/Client";
+import { Params } from "./types/Params";
+
+const url = "https://randomuser.me/api/";
+
+export const fetchUsers = async (params: Params) => {
+  await new Promise<APIResponse>(
+    resolve => setTimeout(resolve, 2000)
+  )
+  return fetch(`${url}?${new URLSearchParams(params)}`).then(
+    response => response.json()
+  )
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,6 @@
 import { AgeGroup } from "./types/AgeGroup";
+import { Params } from "./types/Params";
+import { Nationalities } from "./types/User";
 export const ageGroups: AgeGroup[] = [
   {
     id: 1,
@@ -54,3 +56,20 @@ export const countries: { value: string; label: string }[] = [
     label: "United States",
   },
 ];
+
+export const initParams: Params = {
+  results: "10",
+  inc: "name,phone,cell,location,dob,login,nat",
+  nat: Object.values(countries).map((nat) => nat.value).join()
+}
+
+export const initNationalities: Nationalities = countries.reduce((countries, country) => {
+  return {
+    ...countries,
+    [country.value]: {
+      code: country.value,
+      name: country.label,
+      selected: true,
+    },
+  };
+}, {})

--- a/src/helpers/getNationalitiesParam.ts
+++ b/src/helpers/getNationalitiesParam.ts
@@ -1,0 +1,5 @@
+import { Nationalities } from "../types/User"
+
+export const getNationalitiesParam = (nats: Nationalities) => {
+  return Object.values(nats).filter(nat => nat.selected).map(nat => nat.code).join()
+}

--- a/src/helpers/getSearchParams.ts
+++ b/src/helpers/getSearchParams.ts
@@ -1,0 +1,7 @@
+import { initParams } from "../constants";
+import { Params } from "../types/Params";
+
+export const getSearchParams: (params?: Record<string, string>) => Params = (params) => ({
+  ...initParams,
+  ...params
+});

--- a/src/helpers/promiseWrapper.ts
+++ b/src/helpers/promiseWrapper.ts
@@ -1,0 +1,37 @@
+import { Status } from "../types/Status"
+
+export type Resource<T> = { read: () => T | undefined }
+
+const promiseWrapper: <T>(wrappedPromise: Promise<T>) => Resource<T> = <T>(wrappedPromise: Promise<T>) => {
+  let status: Status = Status.pending
+  let response: T
+
+  const suspender = wrappedPromise.then(
+    (res: T) => {
+      status = Status.resolved
+      response = res
+    },
+    err => {
+      status = Status.rejected
+      response = err
+    }
+  )
+  return {
+    read() {
+      // pending
+      if (status === Status.pending) {
+        throw suspender
+      }
+      // rejected
+      if (status === Status.rejected) {
+        throw response
+      }
+      //resolved
+      if (status === Status.resolved) {
+        return response
+      }
+    }
+  }
+}
+
+export default promiseWrapper

--- a/src/types/Client.ts
+++ b/src/types/Client.ts
@@ -2,4 +2,4 @@ import { User } from "./User";
 
 export type APIResponse = {
   results: User[];
-};
+} | undefined;

--- a/src/types/Params.ts
+++ b/src/types/Params.ts
@@ -1,0 +1,1 @@
+export type Params = Partial<Record<'nat' | 'results' | 'inc', string>>

--- a/src/types/Status.ts
+++ b/src/types/Status.ts
@@ -1,0 +1,5 @@
+export enum Status {
+  pending = 'pending',
+  rejected = 'rejected',
+  resolved = 'resolved'
+}


### PR DESCRIPTION
Moves users fetch request from  useEffect to
top-level of module and uses lzy loading and
Suspense to load the component when it has
data.

- Adds a promiseWrapper to handle async status and read payload
- Adds an ErrorBoundary component
- Wraps the table in Suspense
- Adds disabled state to checkboxes to prevent interaction while requests are pending